### PR TITLE
Copyediting language for consistency and clarity

### DIFF
--- a/IR_Policy/component.yaml
+++ b/IR_Policy/component.yaml
@@ -8,33 +8,33 @@ satisfies:
   narrative:
   - key: a
     text: |
-      Cloud.gov developed an Incident Response Guide documenting the procedures required by the 18F and GSA Incident Response Policy.
+      cloud.gov developed an Incident Response Guide documenting the procedures required by the 18F and GSA Incident Response Policy.
       The guide is disseminated to the whole cloud.gov team to ensure everyone is aware of its existence and contents.
-      The incident response guide can be found here: https://docs.cloud.gov/ops/security-ir/ and it is continually updated based on the changes on the team and the platform.
+      The incident response guide is publicly available at https://docs.cloud.gov/ops/security-ir/ and it is continually updated based on changes to the team and the platform.
   - key: b
     text: |
-      18F reviews, and iterates on, the Incident Response policy at least every 3 years. Cloud.gov reviews, and iterates on, the Incident Response Guide at least annually.
+      18F reviews and iterates on the Incident Response Guide at least every three years. cloud.gov reviews and iterates on the Incident Response Guide at least annually.
 - control_key: IR-2
   covered_by: []
   implementation_status: Planned
   narrative:
   - key: a
     text: |
-      Cloud.gov will make available incident response training to the whole cloud.gov team and require that at least all operators take it.
+      cloud.gov will make incident response training available to the whole cloud.gov team and will require that at least all operators take it.
   - key: b
     text: |
-      If the cloud.gov system changes in a radical way, the incident response training will be adapted to meet the needs of the new system. Cloud.gov operators will be required to take the training again.
+      If the cloud.gov system changes in a radical way, the cloud.gov team will adapt the incident response training to meet the needs of the new system. cloud.gov operators will be required to take the training again.
   - key: c
     text: |
-      At least once a year all operators are required to take the incident response training.
+      cloud.gov requires all operators to take the incident response training at least once a year.
   standard_key: NIST-800-53
 - control_key: IR-3
   covered_by: []
   implementation_status: Planned
   narrative:
   - text: |
-      Cloud.gov will create test plans and exercises in accordance to NIST 800-62 and they will be presented to the cloud.gov Authorizing official for their approval.
-      Tests on the incident response capabilities and related exercises will be done annually.
+      cloud.gov will create test plans and exercises in accordance to NIST 800-62, and it will present these to the cloud.gov Authorizing Official for their approval.
+      cloud.gov will test its incident response capabilities and related exercises annually.
     link: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf
   standard_key: NIST-800-53
 - control_key: IR-3 (2)
@@ -42,7 +42,7 @@ satisfies:
   implementation_status: Implemented
   narrative:
   - text: |
-      Cloud.gov will coordinate with 18F Infrastructure and GSA IT to conduct this exercises in the most effective manner.
+      cloud.gov will coordinate with 18F Infrastructure and GSA IT to conduct these exercises in the most effective manner.
   standard_key: NIST-800-53
 - control_key: IR-4
   covered_by: []
@@ -50,25 +50,25 @@ satisfies:
   narrative:
   - key: a
     text: |
-      Cloud.gov implements automated processes to detect and analyze malicious activity within the platform.
-      If a malicious activity is detected, it is reported to the cloud.gov operations team which in turn is able to use automated tools to eradicate the threat and recover to a known state.
-      Cloud.gov uses a service oriented architecture that allows natural containment and separation.
+      cloud.gov implements automated processes to detect and analyze malicious activity within the platform.
+      If these processes detect malicious activity, they automatically report the activity to the cloud.gov operations team, which is able to use automated tools to eradicate the threat and recover to a known state.
+      cloud.gov uses a service-oriented architecture that allows natural containment and separation.
   - key: b
     text: |
-      The cloud.gov team works as a whole on both contingency planning and incident handling, from operations to communication everyone is involved.
+      The cloud.gov team works as a whole on both contingency planning and incident handling. From operations to communication, everyone is involved.
   - key: c
     text: |
-      After each event response has concluded a retrospective is scheduled and the output of the session is captured in a document accessibe at https://github.com/18F/cg-postmortems/wiki.
+      After the conclusion of each event response, the cloud.gov team schedules a retrospective and captures the output of the session in a document available at https://github.com/18F/cg-postmortems/wiki.
   - key: FedRAMP req
     text: |
-      All cloud.gov personnel has been cleared according to at least tier 1 non-sensitive federal security or an equivalent for contractors.
+      All cloud.gov team members have been cleared according to at least tier 1 non-sensitive federal security or an equivalent for contractors.
   standard_key: NIST-800-53
 - control_key: IR-4 (1)
   covered_by: []
   implementation_status: Partially Implemented
   narrative:
   - text: |
-      Cloud.gov implements automated processes like ClamAV and Tripwire to detect anomalies. Once an anomalie is detected, an alert is escalated using PagerDuty.
+      cloud.gov implements automated processes such as ClamAV and Tripwire to detect anomalies. When these processes detect an anomaly, they escalate an alert using PagerDuty.
       The incident response process is automatically tracked using Slack.
   standard_key: NIST-800-53
 - control_key: IR-5
@@ -76,7 +76,7 @@ satisfies:
   implementation_status: Implemented
   narrative:
   - text: |
-      Cloud.gov tracks all incidents, not just security, using the cloud.gov postmortem wiki: https://github.com/18F/cg-postmortems/wiki. Security incidents are also reported to, and tracked by, to GSA IT.
+      The cloud.gov team tracks all incidents, not just security incidents, using the cloud.gov postmortem wiki: https://github.com/18F/cg-postmortems/wiki. The team also reports security incidents to GSA IT, which also tracks them.
   standard_key: NIST-800-53
 - control_key: IR-6
   covered_by: []
@@ -84,24 +84,24 @@ satisfies:
   narrative:
   - key: a
     text: |
-      Cloud.gov is required to report all suspected security incidents to 18F Infrastructure and GSA IT within the hour of being detected.
+      GSA and 18F require the cloud.gov team to report all suspected security incidents to 18F Infrastructure and GSA IT within the hour of being detected.
   - key: b
     text: |
-      Cloud.gov reports all security activity to 18F Infrastructure and GSA IT according to FedRAMP Incident Communications Procedure.
+      The cloud.gov team reports all security activity to 18F Infrastructure and GSA IT according to FedRAMP Incident Communications Procedure.
   standard_key: NIST-800-53
 - control_key: IR-6 (1)
   covered_by: []
   implementation_status: Partially Implemented
   narrative:
   - text: |
-      Cloud.gov uses automated tools to capture logs and audit trails that allow the communication of security incidents easy and effective.
+      cloud.gov uses automated tools to capture logs and audit trails that allow the communication of security incidents easy and effective.
   standard_key: NIST-800-53
 - control_key: IR-7
   covered_by: []
   implementation_status: Implemented
   narrative:
   - text: |
-      18F provides assistance in regards to security response resources to teams requiring incident response support.
+      18F provides assistance with security response resources to teams requiring incident response support.
   standard_key: NIST-800-53
 - control_key: IR-7 (1)
   covered_by: []
@@ -119,7 +119,7 @@ satisfies:
       18F has direct channels to any external provider of infrastructure and works with them to ensure good cooperation and general application of best practices according to each environment.
   - key: b
     text: |
-      When working with external providers during an incident response all parties have to be identified and cleared before access is granted to any system.
+      When working with external providers during an incident response, all parties have to be identified and cleared before access is granted to any system.
   standard_key: NIST-800-53
 - control_key: IR-8
   covered_by: []
@@ -127,26 +127,26 @@ satisfies:
   narrative:
   - key: a
     text: |
-      Cloud.gov developed both an incident response guide and checklist to implement incident response capabilities.
-      Given the small nature of the cloud.gov team the strucure of the incident response is clear and concise naming the incident commander the first responder to the event.
-      The document provides clear guidance on what steps to take on each situation and how reporting should be handled.
-      The guide empowers the incident commander to leverage as many resources from GSA and 18F as needed during the response process.
-      The incident response documentation is continually reviewed and updated by the cloud.gov team and approved annually by the Authorizing Official.
+      The cloud.gov team has developed both an Incident Response Guide and checklist to implement incident response capabilities.
+      Given the small size of the cloud.gov team, the structure of the incident response process is clear and concise; it assigns the first responder to the event the role of Incident Commander.
+      The Incident Response Guide provides clear guidance on what steps to take on each situation and how reporting should be handled.
+      The Incident Response Guide empowers the Incident Commander to leverage as many resources from GSA and 18F as needed during the response process.
+      The Incident Response Guide is continually reviewed and updated by the cloud.gov team and approved annually by the Authorizing Official.
   - key: b
     text: |
-      The incident response documentation is distributed to the whole of the cloud.gov team.
+      The Incident Response Guide is distributed to the whole of the cloud.gov team.
   - key: c
     text: |
-      The incident response documentation is is continually reviewed and updated by the cloud.gov team.
+      The Incident Response Guide is continually reviewed and updated by the cloud.gov team.
   - key: d
     text: |
-      The incident response documentation is is continually reviewed and updated by the cloud.gov team in response to system and organizational updates.
+      The Incident Response Guide is continually reviewed and updated by the cloud.gov team in response to system and organizational updates.
   - key: e
     text: |
-      Changes to the incident response documentation are distributed to the whole of the cloud.gov team.
+      The cloud.gov team distributes changes to the Incident Response Guide to the whole cloud.gov team.
   - key: f
     text: |
-      The incident response documentation is stored in GitHub as open source. The branch from which the document is generated is a protected one forbidding the unauthorized deletion of revision history. Moreover, there are strict controls on who has authority to approve changes on the documentation.
+      The Incident Response Guide is stored in GitHub as a public open source file. The branch from which the document is generated is a protected branch forbidding the unauthorized deletion of revision history. Moreover, the cloud.gov team has both configured the repository and provided team policies to ensure strict controls on who has authority to approve changes to this guide.
   standard_key: NIST-800-53
 - control_key: IR-9
   covered_by: []
@@ -154,51 +154,51 @@ satisfies:
   narrative:
   - key: a
     text: |
-      As a cloud service provider, cloud.gov doesn't deal with sensitive information directly but allows users to manage their information on the system.
-      All information uploaded by users is treated with the same level of moderate sensitivity once its in a cloud.gov service.
+      As a cloud service provider, cloud.gov does not deal with sensitive information directly but allows users to manage their information on the system.
+      cloud.gov treats all information uploaded by users with the same level of moderate sensitivity once it is in a cloud.gov service.
   - key: b
     text: |
-      Because of the cloud.gov architecture information spillage is not possible without being in a situation of a security breach. Any information spillage will be alerted according to the incident response guide.
+      Because of the cloud.gov architecture, information spillage is not possible without being in a situation of a security breach. Any information spillage will be alerted according to the Incident Response Guide.
   - key: c
     text: |
-      Cloud.gov uses a service oriented architecture as well as offering isolated services for users to store data.
+      cloud.gov uses a service-oriented architecture as well as offering isolated services for users to store data.
   - key: d
     text: |
-      Because of the cloud.gov architecture information spillage is not possible without being in a situation of a security breach. Personnel is instructed to follow the incident response guide in this case.
+      Because of the cloud.gov architecture, information spillage is not possible without being in a situation of a security breach. cloud.gov team members are instructed to follow the Incident Response Guide in this case.
   - key: e
     text: |
-      Because of the cloud.gov architecture information spillage is not possible without being in a situation of a security breach. Personnel is instructed to follow the incident response guide in this case.
+      Because of the cloud.gov architecture, information spillage is not possible without being in a situation of a security breach. cloud.gov team members are instructed to follow the Incident Response Guide in this case.
   - key: f
     text: |
-      Because of the cloud.gov architecture information spillage is not possible without being in a situation of a security breach. Personnel is instructed to follow the incident response guide in this case.
+      Because of the cloud.gov architecture, information spillage is not possible without being in a situation of a security breach. cloud.gov team members are instructed to follow the Incident Response Guide in this case.
   standard_key: NIST-800-53
 - control_key: IR-9 (1)
   covered_by: []
   implementation_status: Planned
   narrative:
   - text: |
-      According to the cloud.gov incident response guide the first responder to an incident will have the responsibility to respond to the information spill.
+      According to the cloud.gov Incident Response Guide, the first responder to an incident will have the responsibility to respond to the information spill.
   standard_key: NIST-800-53
 - control_key: IR-9 (2)
   covered_by: []
   implementation_status: Implemented
   narrative:
   - text: |
-      Because of the cloud.gov architecture information spillage is not possible without being in a situation of a security breach. Personnel is instructed to follow the incident response guide in this case.
+      Because of the cloud.gov architecture, information spillage is not possible without being in a situation of a security breach. cloud.gov team members are instructed to follow the Incident Response Guide in this case.
   standard_key: NIST-800-53
 - control_key: IR-9 (3)
   covered_by: []
   implementation_status: Implemented
   narrative:
   - text: |
-      Because of the cloud.gov architecture information spillage is not possible without being in a situation of a security breach. Personnel is instructed to follow the incident response guide in this case.
+      Because of the cloud.gov architecture, information spillage is not possible without being in a situation of a security breach. cloud.gov team members are instructed to follow the Incident Response Guide in this case.
   standard_key: NIST-800-53
 - control_key: IR-9 (4)
   covered_by: []
   implementation_status: Implemented
   narrative:
   - text: |
-      All cloud.gov personnel has been cleared according to at least tier 1 non-sensitive federal security or an equivalent for contractors.
+      All cloud.gov team members have been cleared according to at least tier 1 non-sensitive federal security or an equivalent for contractors.
   standard_key: NIST-800-53
 schema_version: v3.0.0
 system: 18F


### PR DESCRIPTION
Here are some suggestions to help make these descriptions easier to understand. I made a few changes throughout this document:

* Instead of switching between "Cloud.gov" and "cloud.gov", this always says "cloud.gov".
* I converted most of the passive voice sentences into active voice sentences, so that it's more clear who (or what) is making the control happen.
* I consistently referred to our incident response process as the Incident Response Guide for clarity.
* I switched "cloud.gov personnel" to "the cloud.gov team" to be clear and consistent.

I left a few parts unchanged due to not being sure about the following:

* In this document, “cloud.gov” sometimes seems to mean “the cloud.gov product made of code” and sometime seems to mean “the cloud.gov team of humans”. I’d suggest being very consistent about this and always saying “the cloud.gov team” for human-implemented tasks and “cloud.gov” for code-implemented tasks. I changed some of these, but for some I'm not sure.
* “From operations to communication, everyone is involved.” This could be more clear and specific. Does this mean both operations and communications staff are involved, or does it mean that everyone on the team is involved in both operations and communications tasks?
* “The incident response process is automatically tracked using Slack.” This could be more clear and specific. Does this mean that ClamAV and Tripwire also automatically alert the team via Slack bot integrations in the cloud.gov team channels? Or some other process?
* “cloud.gov uses automated tools to capture logs and audit trails that allow the communication of security incidents easy and effective.” I feel like some words are missing here, but I'm not sure what this should say.